### PR TITLE
modify_post_dm

### DIFF
--- a/post_dm.py
+++ b/post_dm.py
@@ -587,7 +587,7 @@ def send_dm(s):
         "Connection":"keep-alive",
         "Cookie":cookie,
         "Host":"api.live.bilibili.com",
-        "Referer":"http://live.bilibili.com/"+roomid,
+        "Referer":"https://live.bilibili.com/"+roomid,
         "User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36 Vivaldi/2.2.1388.37"
         }
         req = urllib.request.Request(url,postdata,header)


### PR DESCRIPTION
post_dm.py文件中的send_dm函数中
"Referer":"http://live.bilibili.com/"+roomid 改为 "Referer":"https://live.bilibili.com/"+roomid
解决发不出弹幕，并显示[error]send dm error问题